### PR TITLE
Zellij-style tmux status bar, unified catppuccin theming, and shell improvements

### DIFF
--- a/dot_config/fish/functions/fish_greeting.fish
+++ b/dot_config/fish/functions/fish_greeting.fish
@@ -129,6 +129,28 @@ function fish_greeting
         "tv                      fuzzy finder TUI (television)" \
         "tv --preview            fuzzy find with preview"
 
+    # Only show tips once every 6 hours
+    set -l stamp_file ~/.cache/fish_greeting_stamp
+    set -l interval 21600 # 6 hours in seconds
+    set -l now (date +%s)
+    set -l show false
+
+    if not test -f $stamp_file
+        set show true
+    else
+        set -l last (cat $stamp_file)
+        if test (math $now - $last) -ge $interval
+            set show true
+        end
+    end
+
+    if test $show = false
+        return
+    end
+
+    mkdir -p ~/.cache
+    echo $now > $stamp_file
+
     set -l count (count $tips)
     set -l idx1 (random 1 $count)
     set -l idx2 (random 1 $count)

--- a/dot_config/tmux/statusbar-overrides.conf
+++ b/dot_config/tmux/statusbar-overrides.conf
@@ -1,0 +1,33 @@
+# ── Post-TPM Status Bar Overrides ────────────────────────────────────
+# Must be sourced AFTER TPM loads catppuccin, otherwise the plugin
+# overwrites these settings. See statusbar.conf for pre-TPM config.
+
+# ── Activity / Bell ──────────────────────────────────────────────────
+# Solid bg breaks custom separators, so use bold-only styles.
+set -g window-status-activity-style "bold"
+set -g window-status-bell-style "bold"
+
+# ── Status Left: "+" new-window button ──────────────────────────────
+set -g status-left "#[fg=#313244,bg=default]#[fg=#cdd6f4,bg=#313244,bold]+#[fg=#313244,bg=default,nobold] "
+
+# ── Pane Borders ────────────────────────────────────────────────────
+# Zellij-style: subtle, thin, dim.  Catppuccin sets bright borders.
+set -g pane-border-lines single
+set -g pane-border-style "fg=#313244"
+set -g pane-active-border-style "fg=#45475a"
+set -g pane-border-indicators off
+set -g pane-border-status off
+
+# ── Right-Side Pill Overrides ────────────────────────────────────────
+# Text color in each pill matches its primary (icon) color.
+
+# Application pill: flamingo
+set -g @catppuccin_status_application "#[fg=#eba0ac]#[bg=default]#[fg=#11111b,bg=#eba0ac] #[fg=#eba0ac,bg=#313244]#{E:@catppuccin_application_text}#[fg=#313244]#[bg=default] "
+# Host pill: mauve, monitor icon
+set -g @catppuccin_status_host "#[fg=#cba6f7]#[bg=default]#[fg=#11111b,bg=#cba6f7]󰍹 #[fg=#cba6f7,bg=#313244]#{E:@catppuccin_host_text}#[fg=#313244]#[bg=default] "
+# Session pill: constant blue (override catppuccin green/red prefix switch)
+set -g @catppuccin_status_session "#[fg=#89b4fa]#[bg=default]#[fg=#11111b,bg=#89b4fa] #[fg=#89b4fa,bg=#313244]#{E:@catppuccin_session_text}#[fg=#313244]#[bg=default] "
+
+# ── Mode Indicator Pill ──────────────────────────────────────────────
+# Appended to status-right. PREFIX=mauve, COPY=yellow, NORMAL=green.
+set -ag status-right "#{?client_prefix,#[fg=#cba6f7]#[bg=default]#[fg=#11111b#,bg=#cba6f7]󰌶 #[fg=#cba6f7#,bg=#313244] prefix#[fg=#313244]#[bg=default] ,#{?pane_in_mode,#[fg=#f9e2af]#[bg=default]#[fg=#11111b#,bg=#f9e2af]󰌶 #[fg=#f9e2af#,bg=#313244] copy#[fg=#313244]#[bg=default] ,#[fg=#a6e3a1]#[bg=default]#[fg=#11111b#,bg=#a6e3a1]󰌶 #[fg=#a6e3a1#,bg=#313244] normal#[fg=#313244]#[bg=default] }}"

--- a/dot_config/tmux/statusbar.conf
+++ b/dot_config/tmux/statusbar.conf
@@ -1,0 +1,46 @@
+# ── Catppuccin Status Bar ────────────────────────────────────────────
+# Pre-TPM catppuccin theme settings. Sourced before TPM loads the plugin.
+# Post-TPM overrides are in statusbar-overrides.conf (sourced after TPM).
+
+set -g @plugin 'catppuccin/tmux'
+set -g @catppuccin_flavor "mocha"
+
+# ── Tab Styling ──────────────────────────────────────────────────────
+# Custom window separators with catppuccin pill styling.
+# Unfocused tabs: blue.  Focused tab: orange (peach).
+# Activity flag: lavender override on unfocused tabs.
+set -g @catppuccin_status_background "none"
+set -g @catppuccin_window_status_style "custom"
+set -g @catppuccin_window_left_separator "#[fg=##{?window_activity_flag,#{@thm_lavender},#{@thm_blue}},bg=default]#[fg=#{@thm_crust},bg=##{?window_activity_flag,#{@thm_lavender},#{@thm_blue}}]"
+set -g @catppuccin_window_middle_separator " "
+set -g @catppuccin_window_right_separator "#[fg=#{@thm_surface_0},bg=default]"
+set -g @catppuccin_window_current_left_separator "#[fg=#{@thm_peach},bg=default]#[fg=#{@thm_crust},bg=#{@thm_peach}]"
+set -g @catppuccin_window_current_middle_separator " "
+set -g @catppuccin_window_current_right_separator "#[fg=#{@thm_surface_1},bg=default]"
+set -g @catppuccin_status_connect_separator "no"
+
+# ── Tab Content ──────────────────────────────────────────────────────
+# Text color matches the tab's primary color (blue unfocused, peach focused).
+# Shows: window title + pane count.  Icon flags for zoom/activity/bell.
+set -g @catppuccin_status_right_separator " "
+set -g @catppuccin_window_flags "icon"
+set -g @catppuccin_window_text "#{?window_activity_flag,#[bold fg=#{@thm_lavender}],#[fg=#{@thm_blue}]} #T (#{window_panes})"
+set -g @catppuccin_window_current_text "#[fg=#{@thm_peach}] #T (#{window_panes})"
+
+# ── Status Bar Layout ────────────────────────────────────────────────
+# 2-line status: line 1 = tabs + right pills, line 2 = dotted divider.
+set -g status-right-length 200
+set -g status-left-length 100
+set -g status-left ""
+set -g status 2
+set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '·%.0s' $(seq 1 #{client_width}))"
+
+# ── Right-Side Pill Modules ──────────────────────────────────────────
+# Order: containers | application | host | session | mode
+set -g status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "
+set -agF status-right "#{E:@catppuccin_status_application}"
+set -ag status-right "#{E:@catppuccin_status_host}"
+set -ag status-right "#{E:@catppuccin_status_session}"
+
+# ── Statusbar Toggle ────────────────────────────────────────────────
+bind b if -F '#{==:#{status},off}' 'set status 2' 'set status off'

--- a/dot_config/tmux/tmux-which-key/config.yaml
+++ b/dot_config/tmux/tmux-which-key/config.yaml
@@ -33,7 +33,7 @@ macros:
       - run-shell "~/.config/tmux/scripts/container-split.sh -v"
   - name: toggle-status
     commands:
-      - if -F "#{==:#{status},off}" "set status 3" "set status off"
+      - if -F "#{==:#{status},off}" "set status 2" "set status off"
   - name: lazygit-popup
     commands:
       - display-popup -E -w 90% -h 90% -d "#{pane_current_path}" lazygit

--- a/dot_config/tmux/tmux-which-key/config.yaml
+++ b/dot_config/tmux/tmux-which-key/config.yaml
@@ -33,7 +33,7 @@ macros:
       - run-shell "~/.config/tmux/scripts/container-split.sh -v"
   - name: toggle-status
     commands:
-      - if -F "#{==:#{status},off}" "set status on" "set status off"
+      - if -F "#{==:#{status},off}" "set status 2" "set status off"
   - name: lazygit-popup
     commands:
       - display-popup -E -w 90% -h 90% -d "#{pane_current_path}" lazygit

--- a/dot_config/tmux/tmux-which-key/config.yaml
+++ b/dot_config/tmux/tmux-which-key/config.yaml
@@ -1,0 +1,268 @@
+# yaml-language-server: $schema=config.schema.yaml
+# tmux-which-key config — customized for dotfiles keybindings
+# Prefix is C-Space; root_table disabled to avoid conflict
+command_alias_start_index: 200
+keybindings:
+  # root_table: C-Space  # disabled — conflicts with prefix
+  prefix_table: Space
+title:
+  style: align=centre,bold
+  prefix: tmux
+  prefix_style: fg=#cba6f7,align=centre,bold
+position:
+  x: R
+  y: P
+custom_variables:
+  - name: log_info
+    value: "#[fg=#a6e3a1,italics] [info]#[default]#[italics]"
+macros:
+  - name: reload-config
+    commands:
+      - display "#{log_info} Loading config..."
+      - source-file ~/.config/tmux/tmux.conf
+      - display -p "\n\n... Press ENTER to continue"
+  - name: restart-pane
+    commands:
+      - display "#{log_info} Restarting pane"
+      - "respawnp -k -c #{pane_current_path}"
+  - name: container-split-h
+    commands:
+      - "run-shell '~/.config/tmux/scripts/container-split.sh -h'"
+  - name: container-split-v
+    commands:
+      - "run-shell '~/.config/tmux/scripts/container-split.sh -v'"
+items:
+  - name: Run command
+    key: space
+    command: command-prompt
+  - name: Last window
+    key: tab
+    command: last-window
+  - name: Last pane
+    key: "`"
+    command: last-pane
+  - name: Lazygit
+    key: g
+    command: "display-popup -E -w 90% -h 90% -d '#{pane_current_path}' lazygit"
+  - name: Copy mode
+    key: c
+    command: copy-mode
+  - separator: true
+  - name: +Windows
+    key: w
+    menu:
+      - name: Choose tree
+        key: w
+        command: choose-tree -Zw
+      - name: Last
+        key: tab
+        command: last-window
+      - name: Previous
+        key: p
+        command: previous-window
+      - name: Next
+        key: n
+        command: next-window
+      - name: New
+        key: c
+        command: "neww -c #{pane_current_path}"
+      - name: Kill
+        key: x
+        command: 'confirm -p "Kill window #W? (y/n)" killw'
+      - name: Rename
+        key: r
+        command: command-prompt -I "#W" "renamew -- \"%%\""
+      - separator: true
+      - name: +Layout
+        key: l
+        menu:
+          - name: Next
+            key: l
+            command: nextl
+            transient: true
+          - name: Tiled
+            key: t
+            command: selectl tiled
+          - name: Horizontal
+            key: h
+            command: selectl even-horizontal
+          - name: Vertical
+            key: v
+            command: selectl even-vertical
+          - name: Main horizontal
+            key: H
+            command: selectl main-horizontal
+          - name: Main vertical
+            key: V
+            command: selectl main-vertical
+      - name: Rotate
+        key: o
+        command: rotatew
+        transient: true
+  - name: +Panes
+    key: p
+    menu:
+      - name: Last
+        key: tab
+        command: lastp
+      - name: Choose
+        key: p
+        command: displayp -d 0
+      - separator: true
+      - name: Split horizontal (container-aware)
+        key: h
+        macro: container-split-h
+      - name: Split vertical (container-aware)
+        key: v
+        macro: container-split-v
+      - separator: true
+      - name: Left
+        key: Left
+        command: selectp -L
+      - name: Down
+        key: Down
+        command: selectp -D
+      - name: Up
+        key: Up
+        command: selectp -U
+      - name: Right
+        key: Right
+        command: selectp -R
+      - separator: true
+      - name: Zoom
+        key: z
+        command: resizep -Z
+      - name: Swap next
+        key: x
+        command: swapp -t :.+
+      - name: +Resize
+        key: r
+        menu:
+          - name: Left
+            key: h
+            command: resizep -L 5
+            transient: true
+          - name: Down
+            key: j
+            command: resizep -D 5
+            transient: true
+          - name: Up
+            key: k
+            command: resizep -U 5
+            transient: true
+          - name: Right
+            key: l
+            command: resizep -R 5
+            transient: true
+      - name: Break to window
+        key: "!"
+        command: break-pane
+      - separator: true
+      - name: Mark
+        key: m
+        command: selectp -m
+      - name: Unmark
+        key: M
+        command: selectp -M
+      - name: Respawn
+        key: R
+        macro: restart-pane
+      - name: Kill
+        key: X
+        command: 'confirm -p "Kill pane #P? (y/n)" killp'
+  - name: +Sessions
+    key: s
+    menu:
+      - name: Choose
+        key: s
+        command: choose-tree -Zs
+      - name: New
+        key: n
+        command: new-session
+      - name: Rename
+        key: R
+        command: command-prompt -I "#S" "rename-session -- \"%%\""
+      - name: Kill
+        key: X
+        command: 'confirm -p "Kill session #S? (y/n)" kill-session'
+  - name: +Containers
+    key: e
+    menu:
+      - name: Pick container (fzf)
+        key: e
+        command: "display-popup -E -w 80% -h 60% ~/.config/tmux/scripts/container-pick-send.sh"
+      - name: Split horizontal in container
+        key: h
+        macro: container-split-h
+      - name: Split vertical in container
+        key: v
+        macro: container-split-v
+  - name: +Buffers
+    key: b
+    menu:
+      - name: Choose
+        key: b
+        command: choose-buffer -Z
+      - name: List
+        key: l
+        command: lsb
+      - name: Paste
+        key: p
+        command: pasteb
+  - name: +Client
+    key: C
+    menu:
+      - name: Choose
+        key: c
+        command: choose-client -Z
+      - name: Last
+        key: l
+        command: switchc -l
+      - name: Previous
+        key: p
+        command: switchc -p
+      - name: Next
+        key: n
+        command: switchc -n
+      - separator: true
+      - name: Refresh
+        key: R
+        command: refresh
+      - name: Toggle status bar
+        key: b
+        command: "if -F '#{==:#{status},off}' 'set status 2' 'set status off'"
+      - name: +Plugins
+        key: P
+        menu:
+          - name: Install
+            key: i
+            command:
+              run-shell $TMUX_PLUGIN_MANAGER_PATH/tpm/bindings/install_plugins
+          - name: Update
+            key: u
+            command:
+              run-shell $TMUX_PLUGIN_MANAGER_PATH/tpm/bindings/update_plugins
+          - name: Clean
+            key: c
+            command:
+              run-shell $TMUX_PLUGIN_MANAGER_PATH/tpm/bindings/clean_plugins
+      - name: Detach
+        key: D
+        command: detach
+      - separator: true
+      - name: Reload config
+        key: r
+        macro: reload-config
+      - name: Customize
+        key: ","
+        command: customize-mode -Z
+  - separator: true
+  - name: Time
+    key: T
+    command: clock-mode
+  - name: Show messages
+    key: "~"
+    command: show-messages
+  - name: +Keys
+    key: "?"
+    command: list-keys -N

--- a/dot_config/tmux/tmux-which-key/config.yaml
+++ b/dot_config/tmux/tmux-which-key/config.yaml
@@ -24,13 +24,25 @@ macros:
   - name: restart-pane
     commands:
       - display "#{log_info} Restarting pane"
-      - "respawnp -k -c #{pane_current_path}"
+      - respawnp -k -c "#{pane_current_path}"
   - name: container-split-h
     commands:
-      - "run-shell '~/.config/tmux/scripts/container-split.sh -h'"
+      - run-shell "~/.config/tmux/scripts/container-split.sh -h"
   - name: container-split-v
     commands:
-      - "run-shell '~/.config/tmux/scripts/container-split.sh -v'"
+      - run-shell "~/.config/tmux/scripts/container-split.sh -v"
+  - name: toggle-status
+    commands:
+      - if -F "#{==:#{status},off}" "set status 2" "set status off"
+  - name: lazygit-popup
+    commands:
+      - display-popup -E -w 90% -h 90% -d "#{pane_current_path}" lazygit
+  - name: new-window-here
+    commands:
+      - neww -c "#{pane_current_path}"
+  - name: container-pick
+    commands:
+      - display-popup -E -w 80% -h 60% ~/.config/tmux/scripts/container-pick-send.sh
 items:
   - name: Run command
     key: space
@@ -43,7 +55,7 @@ items:
     command: last-pane
   - name: Lazygit
     key: g
-    command: "display-popup -E -w 90% -h 90% -d '#{pane_current_path}' lazygit"
+    macro: lazygit-popup
   - name: Copy mode
     key: c
     command: copy-mode
@@ -65,7 +77,7 @@ items:
         command: next-window
       - name: New
         key: c
-        command: "neww -c #{pane_current_path}"
+        macro: new-window-here
       - name: Kill
         key: x
         command: 'confirm -p "Kill window #W? (y/n)" killw'
@@ -190,7 +202,7 @@ items:
     menu:
       - name: Pick container (fzf)
         key: e
-        command: "display-popup -E -w 80% -h 60% ~/.config/tmux/scripts/container-pick-send.sh"
+        macro: container-pick
       - name: Split horizontal in container
         key: h
         macro: container-split-h
@@ -230,7 +242,7 @@ items:
         command: refresh
       - name: Toggle status bar
         key: b
-        command: "if -F '#{==:#{status},off}' 'set status 2' 'set status off'"
+        macro: toggle-status
       - name: +Plugins
         key: P
         menu:

--- a/dot_config/tmux/tmux-which-key/config.yaml
+++ b/dot_config/tmux/tmux-which-key/config.yaml
@@ -33,7 +33,7 @@ macros:
       - run-shell "~/.config/tmux/scripts/container-split.sh -v"
   - name: toggle-status
     commands:
-      - if -F "#{==:#{status},off}" "set status 2" "set status off"
+      - if -F "#{==:#{status},off}" "set status 3" "set status off"
   - name: lazygit-popup
     commands:
       - display-popup -E -w 90% -h 90% -d "#{pane_current_path}" lazygit

--- a/dot_config/tmux/tmux-which-key/config.yaml
+++ b/dot_config/tmux/tmux-which-key/config.yaml
@@ -33,7 +33,7 @@ macros:
       - run-shell "~/.config/tmux/scripts/container-split.sh -v"
   - name: toggle-status
     commands:
-      - if -F "#{==:#{status},off}" "set status 2" "set status off"
+      - if -F "#{==:#{status},off}" "set status on" "set status off"
   - name: lazygit-popup
     commands:
       - display-popup -E -w 90% -h 90% -d "#{pane_current_path}" lazygit

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -201,15 +201,14 @@ set -g status-left-length 100
 set -g status-left ""
 bind -T root MouseDown1StatusLeft new-window -c "#{pane_current_path}"
 bind -T root MouseDown1StatusRight choose-tree -Zw
-set -g status 2
-set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '▁%.0s' $(seq 1 #{client_width}))"
+set -g status on
 set -g status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "
 set -agF status-right "#{E:@catppuccin_status_application}"
 set -ag status-right "#{E:@catppuccin_status_host}"
 set -ag status-right "#{E:@catppuccin_status_session}"
 
 # ── Statusbar Toggle ──────────────────────────────────────────────────
-bind b if -F '#{==:#{status},off}' 'set status 2' 'set status off'
+bind b if -F '#{==:#{status},off}' 'set status on' 'set status off'
 
 # ── Right-click Menu Fix ─────────────────────────────────────────────
 # Patch right-click menus: add -O flag so menus stay open after release

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -202,7 +202,7 @@ set -g status-left ""
 bind -T root MouseDown1StatusLeft new-window -c "#{pane_current_path}"
 bind -T root MouseDown1StatusRight choose-tree -Zw
 set -g status 2
-set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '▁%.0s' $(seq 1 #{client_width}))"
+set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '·%.0s' $(seq 1 #{client_width}))"
 set -g status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "
 set -agF status-right "#{E:@catppuccin_status_application}"
 set -ag status-right "#{E:@catppuccin_status_host}"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -157,6 +157,7 @@ bind v run-shell "~/.config/tmux/scripts/container-split.sh -v"
 # Mouse: double-click status bar for new window, middle-click tab to close
 bind -T root DoubleClick1Status new-window -c "#{pane_current_path}"
 bind -T root MouseDown2Status kill-window -t=
+unbind -T root MouseDown1StatusRight
 
 # ── Plugins ──────────────────────────────────────────────────────────
 set-environment -g TMUX_PLUGIN_MANAGER_PATH '~/.config/tmux/plugins'

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -202,7 +202,7 @@ set -g status-left ""
 bind -T root MouseDown1StatusLeft new-window -c "#{pane_current_path}"
 bind -T root MouseDown1StatusRight choose-tree -Zw
 set -g status 2
-set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '·%.0s' $(seq 1 #{client_width}))"
+set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '─%.0s' $(seq 1 #{client_width}))"
 set -g status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "
 set -agF status-right "#{E:@catppuccin_status_application}"
 set -ag status-right "#{E:@catppuccin_status_host}"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -201,16 +201,15 @@ set -g status-left-length 100
 set -g status-left ""
 bind -T root MouseDown1StatusLeft new-window -c "#{pane_current_path}"
 bind -T root MouseDown1StatusRight choose-tree -Zw
-set -g status 3
-set -g status-format[1] ""
-set -g status-format[2] "#[fg=#313244,bg=default,fill=default]#(printf '▔%.0s' $(seq 1 #{client_width}))"
+set -g status 2
+set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '▁%.0s' $(seq 1 #{client_width}))"
 set -g status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "
 set -agF status-right "#{E:@catppuccin_status_application}"
 set -ag status-right "#{E:@catppuccin_status_host}"
 set -ag status-right "#{E:@catppuccin_status_session}"
 
 # ── Statusbar Toggle ──────────────────────────────────────────────────
-bind b if -F '#{==:#{status},off}' 'set status 3' 'set status off'
+bind b if -F '#{==:#{status},off}' 'set status 2' 'set status off'
 
 # ── Right-click Menu Fix ─────────────────────────────────────────────
 # Patch right-click menus: add -O flag so menus stay open after release

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -230,6 +230,8 @@ set -g pane-border-lines single
 set -g pane-border-style "fg=#313244"
 set -g pane-active-border-style "fg=#45475a"
 set -g pane-border-indicators off
+set -g pane-border-status top
+set -g pane-border-format ""
 
 # Mode indicator pill appended to end of status-right: PREFIX (mauve), COPY (yellow), NORMAL (dim)
 set -ag status-right "#{?client_prefix,#[fg=#cba6f7#,bg=default]#[fg=#11111b#,bg=#cba6f7#,bold] PREFIX #[fg=#cba6f7#,bg=default#,nobold],#{?pane_in_mode,#[fg=#f9e2af#,bg=default]#[fg=#11111b#,bg=#f9e2af#,bold] COPY #[fg=#f9e2af#,bg=default#,nobold],#[fg=#45475a#,bg=default]#[fg=#a6adc8#,bg=#45475a] NORMAL #[fg=#45475a#,bg=default]}}"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -161,7 +161,6 @@ bind -T root MouseDown2Status kill-window -t=
 # ── Plugins ──────────────────────────────────────────────────────────
 set-environment -g TMUX_PLUGIN_MANAGER_PATH '~/.config/tmux/plugins'
 
-set -g @plugin 'tmux-plugins/tmux-cpu'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'sainnhe/tmux-fzf'
@@ -215,7 +214,6 @@ set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '─%.0s'
 set -g status-right "#{?client_prefix,#[fg=#cba6f7#,bg=default]#[fg=#11111b#,bg=#cba6f7#,bold] PREFIX #[fg=#cba6f7#,bg=default#,nobold],#{?pane_in_mode,#[fg=#f9e2af#,bg=default]#[fg=#11111b#,bg=#f9e2af#,bold] COPY #[fg=#f9e2af#,bg=default#,nobold],#[fg=#45475a#,bg=default]#[fg=#a6adc8#,bg=#45475a] NORMAL #[fg=#45475a#,bg=default]}} "
 set -ag status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "
 set -agF status-right "#{E:@catppuccin_status_application}"
-set -agF status-right "#{E:@catppuccin_status_cpu}"
 set -ag status-right "#{E:@catppuccin_status_host}"
 set -ag status-right "#{E:@catppuccin_status_session}"
 

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -196,6 +196,7 @@ set -g @catppuccin_status_right_separator " "
 set -g @catppuccin_window_flags "icon"
 set -g @catppuccin_window_text "#{?window_activity_flag,#[bold fg=#{@thm_lavender}],} #T (#{window_panes})"
 set -g @catppuccin_window_current_text " #T (#{window_panes})"
+set -g @catppuccin_session_color "#{@thm_blue}"
 set -g status-right-length 200
 set -g status-left-length 100
 set -g status-left ""
@@ -234,4 +235,4 @@ set -g pane-border-indicators off
 set -g pane-border-status off
 
 # Mode indicator pill appended to end of status-right: PREFIX (mauve), COPY (yellow), NORMAL (dim)
-set -ag status-right " #{?client_prefix,#[fg=#cba6f7#,bg=default]#[fg=#11111b#,bg=#cba6f7] 󰌆 #[fg=#cdd6f4#,bg=#313244] PREFIX #[fg=#313244#,bg=default],#{?pane_in_mode,#[fg=#f9e2af#,bg=default]#[fg=#11111b#,bg=#f9e2af] 󰆏 #[fg=#cdd6f4#,bg=#313244] COPY #[fg=#313244#,bg=default],#[fg=#6c7086#,bg=default]#[fg=#11111b#,bg=#6c7086] 󰝦 #[fg=#a6adc8#,bg=#313244] NORMAL #[fg=#313244#,bg=default]}}"
+set -ag status-right "#{?client_prefix,#[fg=#cba6f7]#[bg=default]#[fg=#11111b#,bg=#cba6f7]󰌵 #[fg=#cdd6f4#,bg=#313244]PREFIX#[fg=#313244]#[bg=default] ,#{?pane_in_mode,#[fg=#f9e2af]#[bg=default]#[fg=#11111b#,bg=#f9e2af]󰌵 #[fg=#cdd6f4#,bg=#313244]COPY#[fg=#313244]#[bg=default] ,#[fg=#a6e3a1]#[bg=default]#[fg=#11111b#,bg=#a6e3a1]󰌵 #[fg=#cdd6f4#,bg=#313244]NORMAL#[fg=#313244]#[bg=default] }}"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -200,7 +200,6 @@ set -g status-right-length 200
 set -g status-left-length 100
 set -g status-left ""
 bind -T root MouseDown1StatusLeft new-window -c "#{pane_current_path}"
-bind -T root MouseDown1StatusRight choose-tree -Zw
 set -g status 2
 set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '·%.0s' $(seq 1 #{client_width}))"
 set -g status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -201,8 +201,9 @@ set -g status-left-length 100
 set -g status-left ""
 bind -T root MouseDown1StatusLeft new-window -c "#{pane_current_path}"
 bind -T root MouseDown1StatusRight choose-tree -Zw
-set -g status 2
-set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '▔%.0s' $(seq 1 #{client_width}))"
+set -g status 3
+set -g status-format[1] ""
+set -g status-format[2] "#[fg=#313244,bg=default,fill=default]#(printf '▔%.0s' $(seq 1 #{client_width}))"
 set -g status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "
 set -agF status-right "#{E:@catppuccin_status_application}"
 set -ag status-right "#{E:@catppuccin_status_host}"
@@ -210,11 +211,11 @@ set -ag status-right "#{E:@catppuccin_status_session}"
 
 # ── Statusbar Auto-hide ──────────────────────────────────────────────
 # Show statusbar only when >1 window; toggle manually with prefix+b
-set-hook -g after-new-window         'if -F "#{==:#{session_windows},1}" "set status off" "set status 2"'
-set-hook -g window-unlinked          'if -F "#{==:#{session_windows},1}" "set status off" "set status 2"'
-set-hook -g client-session-changed   'if -F "#{==:#{session_windows},1}" "set status off" "set status 2"'
+set-hook -g after-new-window         'if -F "#{==:#{session_windows},1}" "set status off" "set status 3"'
+set-hook -g window-unlinked          'if -F "#{==:#{session_windows},1}" "set status off" "set status 3"'
+set-hook -g client-session-changed   'if -F "#{==:#{session_windows},1}" "set status off" "set status 3"'
 set-hook -g session-created          'set status off'
-bind b if -F '#{==:#{status},off}' 'set status 2' 'set status off'
+bind b if -F '#{==:#{status},off}' 'set status 3' 'set status off'
 
 # ── Right-click Menu Fix ─────────────────────────────────────────────
 # Patch right-click menus: add -O flag so menus stay open after release

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -190,15 +190,15 @@ set -g @catppuccin_flavor "mocha"
 
 set -g @catppuccin_status_background "none"
 set -g @catppuccin_window_status_style "custom"
-set -g @catppuccin_window_left_separator "#[fg=##{?window_activity_flag,##{@thm_lavender},##{@thm_overlay_2}},bg=default]#[fg=#{@thm_crust},bg=##{?window_activity_flag,##{@thm_lavender},##{@thm_overlay_2}}]"
+set -g @catppuccin_window_left_separator "#[fg=##{?window_activity_flag,##{@thm_lavender},##{@thm_overlay_2}},bg=default]#[fg=#{@thm_crust},bg=##{?window_activity_flag,##{@thm_lavender},##{@thm_overlay_2}}]"
 set -g @catppuccin_window_middle_separator " "
-set -g @catppuccin_window_right_separator "#[fg=#{@thm_surface_0},bg=default]"
-set -g @catppuccin_window_current_left_separator "#[fg=#{@thm_mauve},bg=default]#[fg=#{@thm_crust},bg=#{@thm_mauve}]"
+set -g @catppuccin_window_right_separator "#[fg=#{@thm_surface_0},bg=default]"
+set -g @catppuccin_window_current_left_separator "#[fg=#{@thm_mauve},bg=default]#[fg=#{@thm_crust},bg=#{@thm_mauve}]"
 set -g @catppuccin_window_current_middle_separator " "
-set -g @catppuccin_window_current_right_separator "#[fg=#{@thm_surface_1},bg=default]"
+set -g @catppuccin_window_current_right_separator "#[fg=#{@thm_surface_1},bg=default]"
 set -g @catppuccin_status_connect_separator "no"
 
-set -g @catppuccin_status_right_separator " "
+set -g @catppuccin_status_right_separator " "
 set -g @catppuccin_window_flags "icon"
 set -g @catppuccin_window_text "#{?window_activity_flag,#[bold fg=#{@thm_lavender}],} #T (#{window_panes})"
 set -g @catppuccin_window_current_text " #T (#{window_panes})"
@@ -208,7 +208,7 @@ set -g status-left ""
 bind -T root MouseDown1StatusLeft new-window -c "#{pane_current_path}"
 bind -T root MouseDown1StatusRight choose-tree -Zw
 set -g status 2
-set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '─%.0s' $(seq 1 #{client_width}))"
+set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '▔%.0s' $(seq 1 #{client_width}))"
 # Mode indicator pill: PREFIX (mauve), COPY (yellow), NORMAL (dim)
 # Uses hardcoded Catppuccin Mocha hex to avoid theme variable expansion issues
 set -g status-right "#{?client_prefix,#[fg=#cba6f7#,bg=default]#[fg=#11111b#,bg=#cba6f7#,bold] PREFIX #[fg=#cba6f7#,bg=default#,nobold],#{?pane_in_mode,#[fg=#f9e2af#,bg=default]#[fg=#11111b#,bg=#f9e2af#,bold] COPY #[fg=#f9e2af#,bg=default#,nobold],#[fg=#45475a#,bg=default]#[fg=#a6adc8#,bg=#45475a] NORMAL #[fg=#45475a#,bg=default]}} "

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -196,7 +196,6 @@ set -g @catppuccin_status_right_separator " "
 set -g @catppuccin_window_flags "icon"
 set -g @catppuccin_window_text "#{?window_activity_flag,#[bold fg=#{@thm_lavender}],} #T (#{window_panes})"
 set -g @catppuccin_window_current_text " #T (#{window_panes})"
-set -g @catppuccin_session_color "#{@thm_blue}"
 set -g status-right-length 200
 set -g status-left-length 100
 set -g status-left ""
@@ -234,5 +233,8 @@ set -g pane-active-border-style "fg=#45475a"
 set -g pane-border-indicators off
 set -g pane-border-status off
 
+
+# Session pill: constant blue (override catppuccin green/red prefix switch)
+set -g @catppuccin_status_session "#[fg=#89b4fa]#[bg=default]#[fg=#11111b,bg=#89b4fa] #[fg=#cdd6f4,bg=#313244]#{E:@catppuccin_session_text}#[fg=#313244]#[bg=default] "
 # Mode indicator pill appended to end of status-right: PREFIX (mauve), COPY (yellow), NORMAL (dim)
-set -ag status-right "#{?client_prefix,#[fg=#cba6f7]#[bg=default]#[fg=#11111b#,bg=#cba6f7]󰌵 #[fg=#cdd6f4#,bg=#313244]PREFIX#[fg=#313244]#[bg=default] ,#{?pane_in_mode,#[fg=#f9e2af]#[bg=default]#[fg=#11111b#,bg=#f9e2af]󰌵 #[fg=#cdd6f4#,bg=#313244]COPY#[fg=#313244]#[bg=default] ,#[fg=#a6e3a1]#[bg=default]#[fg=#11111b#,bg=#a6e3a1]󰌵 #[fg=#cdd6f4#,bg=#313244]NORMAL#[fg=#313244]#[bg=default] }}"
+set -ag status-right "#{?client_prefix,#[fg=#cba6f7]#[bg=default]#[fg=#11111b,bg=#cba6f7]󰌵 #[fg=#cdd6f4,bg=#313244] prefix#[fg=#313244]#[bg=default] ,#{?pane_in_mode,#[fg=#f9e2af]#[bg=default]#[fg=#11111b,bg=#f9e2af]󰌵 #[fg=#cdd6f4,bg=#313244] copy#[fg=#313244]#[bg=default] ,#[fg=#a6e3a1]#[bg=default]#[fg=#11111b,bg=#a6e3a1]󰌵 #[fg=#cdd6f4,bg=#313244] normal#[fg=#313244]#[bg=default] }}"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -234,4 +234,4 @@ set -g pane-border-indicators off
 set -g pane-border-status off
 
 # Mode indicator pill appended to end of status-right: PREFIX (mauve), COPY (yellow), NORMAL (dim)
-set -ag status-right " #{?client_prefix,#[fg=#cba6f7#,bg=default]#[fg=#11111b#,bg=#cba6f7#,bold] 󰌆 PREFIX #[fg=#cba6f7#,bg=default#,nobold],#{?pane_in_mode,#[fg=#f9e2af#,bg=default]#[fg=#11111b#,bg=#f9e2af#,bold] 󰆏 COPY #[fg=#f9e2af#,bg=default#,nobold],#[fg=#45475a#,bg=default]#[fg=#a6adc8#,bg=#45475a] 󰝦 NORMAL #[fg=#45475a#,bg=default]}}"
+set -ag status-right " #{?client_prefix,#[fg=#cba6f7#,bg=default]#[fg=#11111b#,bg=#cba6f7] 󰌆 #[fg=#cdd6f4#,bg=#313244] PREFIX #[fg=#313244#,bg=default],#{?pane_in_mode,#[fg=#f9e2af#,bg=default]#[fg=#11111b#,bg=#f9e2af] 󰆏 #[fg=#cdd6f4#,bg=#313244] COPY #[fg=#313244#,bg=default],#[fg=#6c7086#,bg=default]#[fg=#11111b#,bg=#6c7086] 󰝦 #[fg=#a6adc8#,bg=#313244] NORMAL #[fg=#313244#,bg=default]}}"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -178,38 +178,11 @@ set -g @resurrect-strategy-nvim 'session'
 set -g @resurrect-hook-post-save-layout 'sed -i "s|/var/home|/home|g" $1'
 {{- end }}
 
-# ── Catppuccin Theme ─────────────────────────────────────────────────
-# [omarchy override] Uncomment this block to replace the omarchy inline theme
-set -g @plugin 'catppuccin/tmux'
-set -g @catppuccin_flavor "mocha"
-
-set -g @catppuccin_status_background "none"
-set -g @catppuccin_window_status_style "custom"
-set -g @catppuccin_window_left_separator "#[fg=##{?window_activity_flag,##{@thm_lavender},##{@thm_blue}},bg=default]#[fg=#{@thm_crust},bg=##{?window_activity_flag,##{@thm_lavender},##{@thm_blue}}]"
-set -g @catppuccin_window_middle_separator " "
-set -g @catppuccin_window_right_separator "#[fg=#{@thm_surface_0},bg=default]"
-set -g @catppuccin_window_current_left_separator "#[fg=#{@thm_peach},bg=default]#[fg=#{@thm_crust},bg=#{@thm_peach}]"
-set -g @catppuccin_window_current_middle_separator " "
-set -g @catppuccin_window_current_right_separator "#[fg=#{@thm_surface_1},bg=default]"
-set -g @catppuccin_status_connect_separator "no"
-
-set -g @catppuccin_status_right_separator " "
-set -g @catppuccin_window_flags "icon"
-set -g @catppuccin_window_text "#{?window_activity_flag,#[bold fg=#{@thm_lavender}],#[fg=#{@thm_blue}]} #T (#{window_panes})"
-set -g @catppuccin_window_current_text "#[fg=#{@thm_peach}] #T (#{window_panes})"
-set -g status-right-length 200
-set -g status-left-length 100
-set -g status-left ""
+# ── Status Bar ───────────────────────────────────────────────────────
+# [omarchy override] Catppuccin theme + Zellij-style status bar.
+# Split into two files: pre-TPM config and post-TPM overrides.
+source-file ~/.config/tmux/statusbar.conf
 bind -T root MouseDown1StatusLeft new-window -c "#{pane_current_path}"
-set -g status 2
-set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '·%.0s' $(seq 1 #{client_width}))"
-set -g status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "
-set -agF status-right "#{E:@catppuccin_status_application}"
-set -ag status-right "#{E:@catppuccin_status_host}"
-set -ag status-right "#{E:@catppuccin_status_session}"
-
-# ── Statusbar Toggle ──────────────────────────────────────────────────
-bind b if -F '#{==:#{status},off}' 'set status 2' 'set status off'
 
 # ── Right-click Menu Fix ─────────────────────────────────────────────
 # Patch right-click menus: add -O flag so menus stay open after release
@@ -218,28 +191,5 @@ run-shell 'tmux list-keys -T root | grep "MouseDown3.*display-menu" | sed "s/dis
 # Initialize TMUX plugin manager (cloned by chezmoi to ~/.config/tmux/plugins/tpm)
 run '~/.config/tmux/plugins/tpm/tpm'
 
-# ── Post-TPM Overrides ─────────────────────────────────────────────────────
-# Must be after TPM loads catppuccin, otherwise the plugin overwrites them.
-
-# Activity/bell: solid bg breaks custom separators
-set -g window-status-activity-style "bold"
-set -g window-status-bell-style "bold"
-set -g status-left "#[fg=#313244,bg=default]#[fg=#cdd6f4,bg=#313244,bold]+#[fg=#313244,bg=default,nobold] "
-
-# Pane borders (Zellij-style: subtle, thin, dim) -- catppuccin sets bright borders
-set -g pane-border-lines single
-set -g pane-border-style "fg=#313244"
-set -g pane-active-border-style "fg=#45475a"
-set -g pane-border-indicators off
-set -g pane-border-status off
-
-
-# Application pill: flamingo icon, flamingo text
-set -g @catppuccin_status_application "#[fg=#eba0ac]#[bg=default]#[fg=#11111b,bg=#eba0ac] #[fg=#eba0ac,bg=#313244]#{E:@catppuccin_application_text}#[fg=#313244]#[bg=default] "
-# Host pill: mauve monitor icon, mauve text
-set -g @catppuccin_status_host "#[fg=#cba6f7]#[bg=default]#[fg=#11111b,bg=#cba6f7]󰍹 #[fg=#cba6f7,bg=#313244]#{E:@catppuccin_host_text}#[fg=#313244]#[bg=default] "
-
-# Session pill: constant blue (override catppuccin green/red prefix switch)
-set -g @catppuccin_status_session "#[fg=#89b4fa]#[bg=default]#[fg=#11111b,bg=#89b4fa] #[fg=#89b4fa,bg=#313244]#{E:@catppuccin_session_text}#[fg=#313244]#[bg=default] "
-# Mode indicator pill appended to end of status-right: PREFIX (mauve), COPY (yellow), NORMAL (dim)
-set -ag status-right "#{?client_prefix,#[fg=#cba6f7]#[bg=default]#[fg=#11111b#,bg=#cba6f7]󰌶 #[fg=#cba6f7#,bg=#313244] prefix#[fg=#313244]#[bg=default] ,#{?pane_in_mode,#[fg=#f9e2af]#[bg=default]#[fg=#11111b#,bg=#f9e2af]󰌶 #[fg=#f9e2af#,bg=#313244] copy#[fg=#313244]#[bg=default] ,#[fg=#a6e3a1]#[bg=default]#[fg=#11111b#,bg=#a6e3a1]󰌶 #[fg=#a6e3a1#,bg=#313244] normal#[fg=#313244]#[bg=default] }}"
+# Post-TPM overrides (catppuccin overwrites borders, pill styles at load time)
+source-file ~/.config/tmux/statusbar-overrides.conf

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -210,7 +210,10 @@ bind -T root MouseDown1StatusLeft new-window -c "#{pane_current_path}"
 bind -T root MouseDown1StatusRight choose-tree -Zw
 set -g status 2
 set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '─%.0s' $(seq 1 #{client_width}))"
-set -g status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "
+# Mode indicator pill: PREFIX (mauve), COPY (yellow), NORMAL (dim)
+# Uses hardcoded Catppuccin Mocha hex to avoid theme variable expansion issues
+set -g status-right "#{?client_prefix,#[fg=#cba6f7#,bg=default]#[fg=#11111b#,bg=#cba6f7#,bold] PREFIX #[fg=#cba6f7#,bg=default#,nobold],#{?pane_in_mode,#[fg=#f9e2af#,bg=default]#[fg=#11111b#,bg=#f9e2af#,bold] COPY #[fg=#f9e2af#,bg=default#,nobold],#[fg=#45475a#,bg=default]#[fg=#a6adc8#,bg=#45475a] NORMAL #[fg=#45475a#,bg=default]}} "
+set -ag status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "
 set -agF status-right "#{E:@catppuccin_status_application}"
 set -agF status-right "#{E:@catppuccin_status_cpu}"
 set -ag status-right "#{E:@catppuccin_status_host}"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -202,7 +202,7 @@ set -g status-left ""
 bind -T root MouseDown1StatusLeft new-window -c "#{pane_current_path}"
 bind -T root MouseDown1StatusRight choose-tree -Zw
 set -g status 2
-set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '─%.0s' $(seq 1 #{client_width}))"
+set -g status-format[1] "#[fg=#232334,bg=default,fill=default]#(printf '─%.0s' $(seq 1 #{client_width}))"
 set -g status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "
 set -agF status-right "#{E:@catppuccin_status_application}"
 set -ag status-right "#{E:@catppuccin_status_host}"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -165,6 +165,9 @@ set -g @plugin 'tmux-plugins/tmux-cpu'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'sainnhe/tmux-fzf'
+set -g @plugin 'alexwforsythe/tmux-which-key'
+set -g @tmux-which-key-xdg-enable 1
+set -g @tmux-which-key-xdg-plugin-path "tmux/tmux-which-key"
 
 set -g @resurrect-capture-pane-contents 'on'
 set -g @continuum-restore 'off'
@@ -175,6 +178,12 @@ set -g @resurrect-strategy-nvim 'session'
 set -g @resurrect-hook-post-save-layout 'sed -i "s|/var/home|/home|g" $1'
 {{- end }}
 
+# ── Pane Borders (Zellij-style: subtle, thin, dim) ───────────────────
+set -g pane-border-lines single
+set -g pane-border-style "fg=#313244"
+set -g pane-active-border-style "fg=#45475a"
+set -g pane-border-indicators off
+
 # ── Catppuccin Theme ─────────────────────────────────────────────────
 # [omarchy override] Uncomment this block to replace the omarchy inline theme
 set -g @plugin 'catppuccin/tmux'
@@ -182,15 +191,15 @@ set -g @catppuccin_flavor "mocha"
 
 set -g @catppuccin_status_background "none"
 set -g @catppuccin_window_status_style "custom"
-set -g @catppuccin_window_left_separator "#[fg=##{?window_activity_flag,##{@thm_lavender},##{@thm_overlay_2}},bg=default]#[fg=#{@thm_crust},bg=##{?window_activity_flag,##{@thm_lavender},##{@thm_overlay_2}}]"
+set -g @catppuccin_window_left_separator "#[fg=##{?window_activity_flag,##{@thm_lavender},##{@thm_overlay_2}},bg=default]#[fg=#{@thm_crust},bg=##{?window_activity_flag,##{@thm_lavender},##{@thm_overlay_2}}]"
 set -g @catppuccin_window_middle_separator " "
-set -g @catppuccin_window_right_separator "#[fg=#{@thm_surface_0},bg=default]"
-set -g @catppuccin_window_current_left_separator "#[fg=#{@thm_mauve},bg=default]#[fg=#{@thm_crust},bg=#{@thm_mauve}]"
+set -g @catppuccin_window_right_separator "#[fg=#{@thm_surface_0},bg=default]"
+set -g @catppuccin_window_current_left_separator "#[fg=#{@thm_mauve},bg=default]#[fg=#{@thm_crust},bg=#{@thm_mauve}]"
 set -g @catppuccin_window_current_middle_separator " "
-set -g @catppuccin_window_current_right_separator "#[fg=#{@thm_surface_1},bg=default]"
+set -g @catppuccin_window_current_right_separator "#[fg=#{@thm_surface_1},bg=default]"
 set -g @catppuccin_status_connect_separator "no"
 
-set -g @catppuccin_status_right_separator " "
+set -g @catppuccin_status_right_separator " "
 set -g @catppuccin_window_flags "icon"
 set -g @catppuccin_window_text "#{?window_activity_flag,#[bold fg=#{@thm_lavender}],} #T (#{window_panes})"
 set -g @catppuccin_window_current_text " #T (#{window_panes})"
@@ -200,7 +209,7 @@ set -g status-left ""
 bind -T root MouseDown1StatusLeft new-window -c "#{pane_current_path}"
 bind -T root MouseDown1StatusRight choose-tree -Zw
 set -g status 2
-set -g status-format[1] "#[fg=#{@thm_surface_1},bg=default,fill=default]#(printf '·%.0s' $(seq 1 #{client_width}))"
+set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '─%.0s' $(seq 1 #{client_width}))"
 set -g status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "
 set -agF status-right "#{E:@catppuccin_status_application}"
 set -agF status-right "#{E:@catppuccin_status_cpu}"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -202,7 +202,7 @@ set -g status-left ""
 bind -T root MouseDown1StatusLeft new-window -c "#{pane_current_path}"
 bind -T root MouseDown1StatusRight choose-tree -Zw
 set -g status 2
-set -g status-format[1] "#[fg=#232334,bg=default,fill=default]#(printf '─%.0s' $(seq 1 #{client_width}))"
+set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '▁%.0s' $(seq 1 #{client_width}))"
 set -g status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "
 set -agF status-right "#{E:@catppuccin_status_application}"
 set -ag status-right "#{E:@catppuccin_status_host}"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -185,18 +185,18 @@ set -g @catppuccin_flavor "mocha"
 
 set -g @catppuccin_status_background "none"
 set -g @catppuccin_window_status_style "custom"
-set -g @catppuccin_window_left_separator "#[fg=##{?window_activity_flag,##{@thm_lavender},##{@thm_overlay_2}},bg=default]#[fg=#{@thm_crust},bg=##{?window_activity_flag,##{@thm_lavender},##{@thm_overlay_2}}]"
+set -g @catppuccin_window_left_separator "#[fg=##{?window_activity_flag,##{@thm_lavender},##{@thm_blue}},bg=default]#[fg=#{@thm_crust},bg=##{?window_activity_flag,##{@thm_lavender},##{@thm_blue}}]"
 set -g @catppuccin_window_middle_separator " "
 set -g @catppuccin_window_right_separator "#[fg=#{@thm_surface_0},bg=default]"
-set -g @catppuccin_window_current_left_separator "#[fg=#{@thm_mauve},bg=default]#[fg=#{@thm_crust},bg=#{@thm_mauve}]"
+set -g @catppuccin_window_current_left_separator "#[fg=#{@thm_peach},bg=default]#[fg=#{@thm_crust},bg=#{@thm_peach}]"
 set -g @catppuccin_window_current_middle_separator " "
 set -g @catppuccin_window_current_right_separator "#[fg=#{@thm_surface_1},bg=default]"
 set -g @catppuccin_status_connect_separator "no"
 
 set -g @catppuccin_status_right_separator " "
 set -g @catppuccin_window_flags "icon"
-set -g @catppuccin_window_text "#{?window_activity_flag,#[bold fg=#{@thm_lavender}],} #T (#{window_panes})"
-set -g @catppuccin_window_current_text " #T (#{window_panes})"
+set -g @catppuccin_window_text "#{?window_activity_flag,#[bold fg=#{@thm_lavender}],#[fg=#{@thm_blue}]} #T (#{window_panes})"
+set -g @catppuccin_window_current_text "#[fg=#{@thm_peach}] #T (#{window_panes})"
 set -g status-right-length 200
 set -g status-left-length 100
 set -g status-left ""
@@ -234,7 +234,12 @@ set -g pane-border-indicators off
 set -g pane-border-status off
 
 
+# Application pill: flamingo icon, flamingo text
+set -g @catppuccin_status_application "#[fg=#eba0ac]#[bg=default]#[fg=#11111b,bg=#eba0ac] #[fg=#eba0ac,bg=#313244]#{E:@catppuccin_application_text}#[fg=#313244]#[bg=default] "
+# Host pill: mauve monitor icon, mauve text
+set -g @catppuccin_status_host "#[fg=#cba6f7]#[bg=default]#[fg=#11111b,bg=#cba6f7]󰍹 #[fg=#cba6f7,bg=#313244]#{E:@catppuccin_host_text}#[fg=#313244]#[bg=default] "
+
 # Session pill: constant blue (override catppuccin green/red prefix switch)
-set -g @catppuccin_status_session "#[fg=#89b4fa]#[bg=default]#[fg=#11111b,bg=#89b4fa] #[fg=#cdd6f4,bg=#313244]#{E:@catppuccin_session_text}#[fg=#313244]#[bg=default] "
+set -g @catppuccin_status_session "#[fg=#89b4fa]#[bg=default]#[fg=#11111b,bg=#89b4fa] #[fg=#89b4fa,bg=#313244]#{E:@catppuccin_session_text}#[fg=#313244]#[bg=default] "
 # Mode indicator pill appended to end of status-right: PREFIX (mauve), COPY (yellow), NORMAL (dim)
-set -ag status-right "#{?client_prefix,#[fg=#cba6f7]#[bg=default]#[fg=#11111b#,bg=#cba6f7]󰌵 #[fg=#cdd6f4#,bg=#313244] prefix#[fg=#313244]#[bg=default] ,#{?pane_in_mode,#[fg=#f9e2af]#[bg=default]#[fg=#11111b#,bg=#f9e2af]󰌵 #[fg=#cdd6f4#,bg=#313244] copy#[fg=#313244]#[bg=default] ,#[fg=#a6e3a1]#[bg=default]#[fg=#11111b#,bg=#a6e3a1]󰌵 #[fg=#cdd6f4#,bg=#313244] normal#[fg=#313244]#[bg=default] }}"
+set -ag status-right "#{?client_prefix,#[fg=#cba6f7]#[bg=default]#[fg=#11111b#,bg=#cba6f7]󰌶 #[fg=#cba6f7#,bg=#313244] prefix#[fg=#313244]#[bg=default] ,#{?pane_in_mode,#[fg=#f9e2af]#[bg=default]#[fg=#11111b#,bg=#f9e2af]󰌶 #[fg=#f9e2af#,bg=#313244] copy#[fg=#313244]#[bg=default] ,#[fg=#a6e3a1]#[bg=default]#[fg=#11111b#,bg=#a6e3a1]󰌶 #[fg=#a6e3a1#,bg=#313244] normal#[fg=#313244]#[bg=default] }}"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -234,4 +234,4 @@ set -g pane-border-indicators off
 set -g pane-border-status off
 
 # Mode indicator pill appended to end of status-right: PREFIX (mauve), COPY (yellow), NORMAL (dim)
-set -ag status-right "#{?client_prefix,#[fg=#cba6f7#,bg=default]#[fg=#11111b#,bg=#cba6f7#,bold] PREFIX #[fg=#cba6f7#,bg=default#,nobold],#{?pane_in_mode,#[fg=#f9e2af#,bg=default]#[fg=#11111b#,bg=#f9e2af#,bold] COPY #[fg=#f9e2af#,bg=default#,nobold],#[fg=#45475a#,bg=default]#[fg=#a6adc8#,bg=#45475a] NORMAL #[fg=#45475a#,bg=default]}}"
+set -ag status-right " #{?client_prefix,#[fg=#cba6f7#,bg=default]#[fg=#11111b#,bg=#cba6f7#,bold] 󰌆 PREFIX #[fg=#cba6f7#,bg=default#,nobold],#{?pane_in_mode,#[fg=#f9e2af#,bg=default]#[fg=#11111b#,bg=#f9e2af#,bold] 󰆏 COPY #[fg=#f9e2af#,bg=default#,nobold],#[fg=#45475a#,bg=default]#[fg=#a6adc8#,bg=#45475a] 󰝦 NORMAL #[fg=#45475a#,bg=default]}}"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -209,12 +209,7 @@ set -agF status-right "#{E:@catppuccin_status_application}"
 set -ag status-right "#{E:@catppuccin_status_host}"
 set -ag status-right "#{E:@catppuccin_status_session}"
 
-# ── Statusbar Auto-hide ──────────────────────────────────────────────
-# Show statusbar only when >1 window; toggle manually with prefix+b
-set-hook -g after-new-window         'if -F "#{==:#{session_windows},1}" "set status off" "set status 3"'
-set-hook -g window-unlinked          'if -F "#{==:#{session_windows},1}" "set status off" "set status 3"'
-set-hook -g client-session-changed   'if -F "#{==:#{session_windows},1}" "set status off" "set status 3"'
-set-hook -g session-created          'set status off'
+# ── Statusbar Toggle ──────────────────────────────────────────────────
 bind b if -F '#{==:#{status},off}' 'set status 3' 'set status off'
 
 # ── Right-click Menu Fix ─────────────────────────────────────────────

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -177,12 +177,6 @@ set -g @resurrect-strategy-nvim 'session'
 set -g @resurrect-hook-post-save-layout 'sed -i "s|/var/home|/home|g" $1'
 {{- end }}
 
-# ── Pane Borders (Zellij-style: subtle, thin, dim) ───────────────────
-set -g pane-border-lines single
-set -g pane-border-style "fg=#313244"
-set -g pane-active-border-style "fg=#45475a"
-set -g pane-border-indicators off
-
 # ── Catppuccin Theme ─────────────────────────────────────────────────
 # [omarchy override] Uncomment this block to replace the omarchy inline theme
 set -g @plugin 'catppuccin/tmux'
@@ -209,10 +203,7 @@ bind -T root MouseDown1StatusLeft new-window -c "#{pane_current_path}"
 bind -T root MouseDown1StatusRight choose-tree -Zw
 set -g status 2
 set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '▔%.0s' $(seq 1 #{client_width}))"
-# Mode indicator pill: PREFIX (mauve), COPY (yellow), NORMAL (dim)
-# Uses hardcoded Catppuccin Mocha hex to avoid theme variable expansion issues
-set -g status-right "#{?client_prefix,#[fg=#cba6f7#,bg=default]#[fg=#11111b#,bg=#cba6f7#,bold] PREFIX #[fg=#cba6f7#,bg=default#,nobold],#{?pane_in_mode,#[fg=#f9e2af#,bg=default]#[fg=#11111b#,bg=#f9e2af#,bold] COPY #[fg=#f9e2af#,bg=default#,nobold],#[fg=#45475a#,bg=default]#[fg=#a6adc8#,bg=#45475a] NORMAL #[fg=#45475a#,bg=default]}} "
-set -ag status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "
+set -g status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "
 set -agF status-right "#{E:@catppuccin_status_application}"
 set -ag status-right "#{E:@catppuccin_status_host}"
 set -ag status-right "#{E:@catppuccin_status_session}"
@@ -232,8 +223,19 @@ run-shell 'tmux list-keys -T root | grep "MouseDown3.*display-menu" | sed "s/dis
 # Initialize TMUX plugin manager (cloned by chezmoi to ~/.config/tmux/plugins/tpm)
 run '~/.config/tmux/plugins/tpm/tpm'
 
-# Override catppuccin's activity/bell styles (must be after TPM loads the plugin,
-# otherwise the plugin's set -gF overwrites them). Solid bg breaks custom separators.
+# ── Post-TPM Overrides ─────────────────────────────────────────────────────
+# Must be after TPM loads catppuccin, otherwise the plugin overwrites them.
+
+# Activity/bell: solid bg breaks custom separators
 set -g window-status-activity-style "bold"
 set -g window-status-bell-style "bold"
 set -g status-left "#[fg=#313244,bg=default]#[fg=#cdd6f4,bg=#313244,bold]+#[fg=#313244,bg=default,nobold] "
+
+# Pane borders (Zellij-style: subtle, thin, dim) -- catppuccin sets bright borders
+set -g pane-border-lines single
+set -g pane-border-style "fg=#313244"
+set -g pane-active-border-style "fg=#45475a"
+set -g pane-border-indicators off
+
+# Mode indicator pill appended to end of status-right: PREFIX (mauve), COPY (yellow), NORMAL (dim)
+set -ag status-right "#{?client_prefix,#[fg=#cba6f7#,bg=default]#[fg=#11111b#,bg=#cba6f7#,bold] PREFIX #[fg=#cba6f7#,bg=default#,nobold],#{?pane_in_mode,#[fg=#f9e2af#,bg=default]#[fg=#11111b#,bg=#f9e2af#,bold] COPY #[fg=#f9e2af#,bg=default#,nobold],#[fg=#45475a#,bg=default]#[fg=#a6adc8#,bg=#45475a] NORMAL #[fg=#45475a#,bg=default]}}"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -202,7 +202,7 @@ set -g status-left ""
 bind -T root MouseDown1StatusLeft new-window -c "#{pane_current_path}"
 bind -T root MouseDown1StatusRight choose-tree -Zw
 set -g status 2
-set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '▔%.0s' $(seq 1 #{client_width}))"
+set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '·%.0s' $(seq 1 #{client_width}))"
 set -g status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "
 set -agF status-right "#{E:@catppuccin_status_application}"
 set -ag status-right "#{E:@catppuccin_status_host}"
@@ -231,6 +231,7 @@ set -g pane-border-lines single
 set -g pane-border-style "fg=#313244"
 set -g pane-active-border-style "fg=#45475a"
 set -g pane-border-indicators off
+set -g pane-border-status off
 
 # Mode indicator pill appended to end of status-right: PREFIX (mauve), COPY (yellow), NORMAL (dim)
 set -ag status-right "#{?client_prefix,#[fg=#cba6f7#,bg=default]#[fg=#11111b#,bg=#cba6f7#,bold] PREFIX #[fg=#cba6f7#,bg=default#,nobold],#{?pane_in_mode,#[fg=#f9e2af#,bg=default]#[fg=#11111b#,bg=#f9e2af#,bold] COPY #[fg=#f9e2af#,bg=default#,nobold],#[fg=#45475a#,bg=default]#[fg=#a6adc8#,bg=#45475a] NORMAL #[fg=#45475a#,bg=default]}}"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -201,14 +201,15 @@ set -g status-left-length 100
 set -g status-left ""
 bind -T root MouseDown1StatusLeft new-window -c "#{pane_current_path}"
 bind -T root MouseDown1StatusRight choose-tree -Zw
-set -g status on
+set -g status 2
+set -g status-format[1] "#[fg=#313244,bg=default,fill=default]#(printf '▔%.0s' $(seq 1 #{client_width}))"
 set -g status-right "#[fg=#{@thm_mauve}]#(~/.config/tmux/scripts/container-status.sh) "
 set -agF status-right "#{E:@catppuccin_status_application}"
 set -ag status-right "#{E:@catppuccin_status_host}"
 set -ag status-right "#{E:@catppuccin_status_session}"
 
 # ── Statusbar Toggle ──────────────────────────────────────────────────
-bind b if -F '#{==:#{status},off}' 'set status on' 'set status off'
+bind b if -F '#{==:#{status},off}' 'set status 2' 'set status off'
 
 # ── Right-click Menu Fix ─────────────────────────────────────────────
 # Patch right-click menus: add -O flag so menus stay open after release
@@ -230,8 +231,6 @@ set -g pane-border-lines single
 set -g pane-border-style "fg=#313244"
 set -g pane-active-border-style "fg=#45475a"
 set -g pane-border-indicators off
-set -g pane-border-status top
-set -g pane-border-format ""
 
 # Mode indicator pill appended to end of status-right: PREFIX (mauve), COPY (yellow), NORMAL (dim)
 set -ag status-right "#{?client_prefix,#[fg=#cba6f7#,bg=default]#[fg=#11111b#,bg=#cba6f7#,bold] PREFIX #[fg=#cba6f7#,bg=default#,nobold],#{?pane_in_mode,#[fg=#f9e2af#,bg=default]#[fg=#11111b#,bg=#f9e2af#,bold] COPY #[fg=#f9e2af#,bg=default#,nobold],#[fg=#45475a#,bg=default]#[fg=#a6adc8#,bg=#45475a] NORMAL #[fg=#45475a#,bg=default]}}"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -237,4 +237,4 @@ set -g pane-border-status off
 # Session pill: constant blue (override catppuccin green/red prefix switch)
 set -g @catppuccin_status_session "#[fg=#89b4fa]#[bg=default]#[fg=#11111b,bg=#89b4fa] #[fg=#cdd6f4,bg=#313244]#{E:@catppuccin_session_text}#[fg=#313244]#[bg=default] "
 # Mode indicator pill appended to end of status-right: PREFIX (mauve), COPY (yellow), NORMAL (dim)
-set -ag status-right "#{?client_prefix,#[fg=#cba6f7]#[bg=default]#[fg=#11111b,bg=#cba6f7]󰌵 #[fg=#cdd6f4,bg=#313244] prefix#[fg=#313244]#[bg=default] ,#{?pane_in_mode,#[fg=#f9e2af]#[bg=default]#[fg=#11111b,bg=#f9e2af]󰌵 #[fg=#cdd6f4,bg=#313244] copy#[fg=#313244]#[bg=default] ,#[fg=#a6e3a1]#[bg=default]#[fg=#11111b,bg=#a6e3a1]󰌵 #[fg=#cdd6f4,bg=#313244] normal#[fg=#313244]#[bg=default] }}"
+set -ag status-right "#{?client_prefix,#[fg=#cba6f7]#[bg=default]#[fg=#11111b#,bg=#cba6f7]󰌵 #[fg=#cdd6f4#,bg=#313244] prefix#[fg=#313244]#[bg=default] ,#{?pane_in_mode,#[fg=#f9e2af]#[bg=default]#[fg=#11111b#,bg=#f9e2af]󰌵 #[fg=#cdd6f4#,bg=#313244] copy#[fg=#313244]#[bg=default] ,#[fg=#a6e3a1]#[bg=default]#[fg=#11111b#,bg=#a6e3a1]󰌵 #[fg=#cdd6f4#,bg=#313244] normal#[fg=#313244]#[bg=default] }}"

--- a/dot_config/zellij/layouts/default.kdl
+++ b/dot_config/zellij/layouts/default.kdl
@@ -31,7 +31,7 @@ layout {
 
                 format_left   "{tabs}"
                 format_center "{notifications}"
-                format_right  "#[bg=default,fg=#b4befe]#[bg=#b4befe,fg=#11111b]⮁ #[bg=#45475a,fg=#b4befe,bold] {swap_layout}#[bg=default,fg=#45475a] #[bg=default,fg=#cba6f7]#[bg=#cba6f7,fg=#11111b] #[bg=#45475a,fg=#cba6f7,bold] {command_hostname}#[bg=default,fg=#45475a] #[bg=default,fg=#74c7ec]#[bg=#74c7ec,fg=#11111b,bold] {session} #[bg=default] {mode}"
+                format_right  "#[bg=default,fg=#b4befe]#[bg=#b4befe,fg=#11111b]⮁ #[bg=#45475a,fg=#b4befe,bold] {swap_layout}#[bg=default,fg=#45475a] #[bg=default,fg=#cba6f7]#[bg=#cba6f7,fg=#11111b] #[bg=#45475a,fg=#cba6f7,bold] {command_hostname}#[bg=default,fg=#45475a] #[bg=default,fg=#74c7ec]#[bg=#74c7ec,fg=#11111b] #[bg=#45475a,fg=#74c7ec,bold] {command_session_count}#[bg=default,fg=#45475a] {mode}"
                 format_space  ""
                 format_hide_on_overlength "true"
                 format_precedence "rlc"
@@ -41,19 +41,19 @@ layout {
                 border_format   "#[fg=#313244]{char}"
                 border_position "bottom"
 
-                mode_normal       "#[bg=#a6e3a1,fg=#11111b,bold] NORMAL#[bg=default,fg=#a6e3a1]"
-                mode_locked       "#[bg=#f38ba8,fg=#11111b,bold] LOCKED#[bg=default,fg=#f38ba8]"
-                mode_pane         "#[bg=#94e2d5,fg=#11111b,bold] PANE#[bg=default,fg=#94e2d5]"
-                mode_tab          "#[bg=#94e2d5,fg=#11111b,bold] TAB#[bg=default,fg=#94e2d5]"
-                mode_resize       "#[bg=#f9e2af,fg=#11111b,bold] RESIZE#[bg=default,fg=#f9e2af]"
-                mode_move         "#[bg=#f9e2af,fg=#11111b,bold] MOVE#[bg=default,fg=#f9e2af]"
-                mode_scroll       "#[bg=#f2cdcd,fg=#11111b,bold] SCROLL#[bg=default,fg=#f2cdcd]"
-                mode_search       "#[bg=#f2cdcd,fg=#11111b,bold] SEARCH#[bg=default,fg=#f2cdcd]"
-                mode_enter_search "#[bg=#f2cdcd,fg=#11111b,bold] SEARCH#[bg=default,fg=#f2cdcd]"
-                mode_session      "#[bg=#f5c2e7,fg=#11111b,bold] SESSION#[bg=default,fg=#f5c2e7]"
-                mode_tmux         "#[bg=#cba6f7,fg=#11111b,bold] TMUX#[bg=default,fg=#cba6f7]"
-                mode_rename_tab   "#[bg=#f9e2af,fg=#11111b,bold] RENAME#[bg=default,fg=#f9e2af]"
-                mode_rename_pane  "#[bg=#f9e2af,fg=#11111b,bold] RENAME#[bg=default,fg=#f9e2af]"
+                mode_normal           "#[bg=default,fg=#a6e3a1]#[bg=#a6e3a1,fg=#11111b]󰌶 #[bg=#45475a,fg=#a6e3a1,bold] normal#[bg=default,fg=#45475a]"
+                mode_locked           "#[bg=default,fg=#f38ba8]#[bg=#f38ba8,fg=#11111b]󰌶 #[bg=#45475a,fg=#f38ba8,bold] locked#[bg=default,fg=#45475a]"
+                mode_pane             "#[bg=default,fg=#94e2d5]#[bg=#94e2d5,fg=#11111b]󰌶 #[bg=#45475a,fg=#94e2d5,bold] pane#[bg=default,fg=#45475a]"
+                mode_tab              "#[bg=default,fg=#94e2d5]#[bg=#94e2d5,fg=#11111b]󰌶 #[bg=#45475a,fg=#94e2d5,bold] tab#[bg=default,fg=#45475a]"
+                mode_resize           "#[bg=default,fg=#f9e2af]#[bg=#f9e2af,fg=#11111b]󰌶 #[bg=#45475a,fg=#f9e2af,bold] resize#[bg=default,fg=#45475a]"
+                mode_move             "#[bg=default,fg=#f9e2af]#[bg=#f9e2af,fg=#11111b]󰌶 #[bg=#45475a,fg=#f9e2af,bold] move#[bg=default,fg=#45475a]"
+                mode_scroll           "#[bg=default,fg=#f2cdcd]#[bg=#f2cdcd,fg=#11111b]󰌶 #[bg=#45475a,fg=#f2cdcd,bold] scroll#[bg=default,fg=#45475a]"
+                mode_search           "#[bg=default,fg=#f2cdcd]#[bg=#f2cdcd,fg=#11111b]󰌶 #[bg=#45475a,fg=#f2cdcd,bold] search#[bg=default,fg=#45475a]"
+                mode_enter_search     "#[bg=default,fg=#f2cdcd]#[bg=#f2cdcd,fg=#11111b]󰌶 #[bg=#45475a,fg=#f2cdcd,bold] search#[bg=default,fg=#45475a]"
+                mode_session          "#[bg=default,fg=#f5c2e7]#[bg=#f5c2e7,fg=#11111b]󰌶 #[bg=#45475a,fg=#f5c2e7,bold] session#[bg=default,fg=#45475a]"
+                mode_tmux             "#[bg=default,fg=#cba6f7]#[bg=#cba6f7,fg=#11111b]󰌶 #[bg=#45475a,fg=#cba6f7,bold] tmux#[bg=default,fg=#45475a]"
+                mode_rename_tab       "#[bg=default,fg=#f9e2af]#[bg=#f9e2af,fg=#11111b]󰌶 #[bg=#45475a,fg=#f9e2af,bold] rename#[bg=default,fg=#45475a]"
+                mode_rename_pane      "#[bg=default,fg=#f9e2af]#[bg=#f9e2af,fg=#11111b]󰌶 #[bg=#45475a,fg=#f9e2af,bold] rename#[bg=default,fg=#45475a]"
 
                 tab_normal              "#[bg=default,fg=#89b4fa]#[bg=#89b4fa,fg=#11111b,bold]{index} #[bg=#45475a,fg=#89b4fa,bold] {name}{floating_indicator}#[bg=default,fg=#45475a]"
                 tab_normal_fullscreen   "#[bg=default,fg=#89b4fa]#[bg=#89b4fa,fg=#11111b,bold]{index} #[bg=#45475a,fg=#89b4fa,bold] {name}{fullscreen_indicator}#[bg=default,fg=#45475a]"
@@ -78,6 +78,11 @@ layout {
                 command_hostname_format        "{stdout}"
                 command_hostname_interval      "0"
                 command_hostname_rendermode    "static"
+
+                command_session_count_command    "sh -c 'zellij list-sessions 2>/dev/null | grep -cv EXITED'" 
+                command_session_count_format     "{stdout}"
+                command_session_count_interval   "5"
+                command_session_count_rendermode "dynamic"
 
             }
         }


### PR DESCRIPTION
## Summary

- **Tmux status bar redesign**: Zellij-inspired catppuccin mocha theme with two-tone pills, blue/orange tab colors, dim pane borders, dotted divider line, and mode indicator (normal/prefix/copy)
- **Tmux config split**: Status bar theming extracted into `statusbar.conf` (pre-TPM) and `statusbar-overrides.conf` (post-TPM) for maintainability
- **tmux-which-key plugin**: Keybinding discovery menu (prefix+Space) with all dotfiles bindings organized into categories
- **Zellij status bar**: Matching two-tone mode/session pills with lowercase text, session count replacing session name, catppuccin pill styling
- **Fish greeting throttle**: CLI tips now show once every 6 hours instead of every new terminal

## Details

### Tmux
- Catppuccin mocha pills with colored text matching each pill's primary color (flamingo app, mauve host, blue session, green/mauve/yellow mode)
- Icons matching Zellij: `󰍹` monitor (host), `` terminal-tmux (session), `󰌶` lightbulb outline (mode)
- Removed CPU plugin, auto-hide status bar, and right-status click handlers
- Post-TPM overrides for pane borders and pill styles (catppuccin overwrites at load time)

### Zellij
- zjstatus pills converted to two-tone style (colored icon left, surface bg text right)
- Mode indicators use lowercase text with lightbulb outline icon
- Session name replaced with active session count via `zellij list-sessions | grep -cv EXITED`

### Fish
- `fish_greeting` writes timestamp to `~/.cache/fish_greeting_stamp`, only shows tips after 6-hour cooldown