### PR TITLE
terminals: adopt omarchy CSI-u Shift+Enter keybinds and tmux pane controls

### DIFF
--- a/dot_config/ghostty/config.tmpl
+++ b/dot_config/ghostty/config.tmpl
@@ -31,6 +31,10 @@ shell-integration-features = no-cursor,ssh-env
 # Keyboard bindings
 keybind = shift+insert=paste_from_clipboard
 keybind = control+insert=copy_to_clipboard
+# Send Shift+Enter as CSI-u so TUIs can distinguish it from Enter.
+keybind = shift+enter=csi:13;2u
+# Legacy encoding sends Alt+Shift+Enter the same as Alt+Enter; send CSI-u so tmux can match M-S-Enter.
+keybind = alt+shift+enter=csi:13;4u
 keybind = super+control+shift+alt+arrow_down=resize_split:down,100
 keybind = super+control+shift+alt+arrow_up=resize_split:up,100
 keybind = super+control+shift+alt+arrow_left=resize_split:left,100

--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -17,6 +17,10 @@ confirm_os_window_close 0
 # Keybindings
 map ctrl+insert copy_to_clipboard
 map shift+insert paste_from_clipboard
+# Send Shift+Enter as CSI-u so TUIs can distinguish it from Enter.
+map shift+enter send_text all \e[13;2u
+# Kitty legacy encoding sends Alt+Shift+Enter the same as Alt+Enter; send CSI-u so tmux can match M-S-Enter.
+map alt+shift+enter send_text all \e[13;4u
 
 # Allow remote access
 allow_remote_control yes

--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -12,6 +12,9 @@ bind -T copy-mode-vi v send -X begin-selection
 bind -T copy-mode-vi y send -X copy-selection-and-cancel
 
 # Pane Controls
+bind -n M-Enter split-window -v -c "#{pane_current_path}"
+bind -n M-S-Enter split-window -h -c "#{pane_current_path}"
+bind -n M-Escape kill-pane
 bind h split-window -v -c "#{pane_current_path}"
 bind v split-window -h -c "#{pane_current_path}"
 bind x kill-pane
@@ -72,6 +75,7 @@ setw -g aggressive-resize on
 set -g detach-on-destroy off
 set -g extended-keys on
 set -g extended-keys-format csi-u
+set -ag terminal-features "xterm-kitty:extkeys"
 set -sg escape-time 10
 
 # Status bar
@@ -82,6 +86,8 @@ set -g status-right-length 50
 set -g window-status-separator ""
 set -gw automatic-rename on
 set -gw automatic-rename-format '#{b:pane_current_path}'
+set -g set-titles on
+set -g set-titles-string '#h:#W'
 
 # Theme
 set -g status-style "bg=default,fg=default"


### PR DESCRIPTION
Omarchy 3.8.3 migration `1783833508` edited the live terminal configs in place. This syncs those changes into the chezmoi source so `chezmoi apply` doesn't revert them:

- **tmux.conf**: `Alt+Enter` / `Alt+Shift+Enter` pane splits, `Alt+Escape` kill-pane, kitty extkeys terminal-features, terminal titles (`#h:#W`)
- **ghostty** (template) and **kitty**: `Shift+Enter` → `CSI 13;2u`, `Alt+Shift+Enter` → `CSI 13;4u` so TUIs can distinguish them from plain Enter

foot.ini and alacritty.toml received the same migration edits but aren't chezmoi-managed. Verified `chezmoi diff` is clean for all three files and no existing bindings conflict with the new tmux pane controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)