### PR TITLE
fish: switch mise from shims to PATH activation

### DIFF
--- a/dot_config/fish/conf.d/zz_01_paths.fish.tmpl
+++ b/dot_config/fish/conf.d/zz_01_paths.fish.tmpl
@@ -19,7 +19,11 @@ fish_add_path -a --path $OMARCHY_PATH/bin
 {{ end -}}
 
 # Mise - polyglot runtime version manager (Java, Python, Node, etc.)
-__cached_source mise activate --shims fish
+# PATH activation (not --shims): a fish_prompt hook runs `mise hook-env`, which
+# puts the real tool bin dirs (incl. ~/.cargo/bin) on PATH — so binaries added
+# by `cargo install` / `npm i -g` work without a `mise reshim`. hook-env keeps
+# entries added after activation (like the overrides move below) in front.
+__cached_source mise activate fish
 
 # Custom bins
 fish_add_path -a --path ~/.local/bin

--- a/dot_config/fish/conf.d/zz_03_interactive.fish
+++ b/dot_config/fish/conf.d/zz_03_interactive.fish
@@ -37,10 +37,11 @@ if status is-interactive
         end
     end
 
-    # Auto-activate Python virtualenvs on `cd` (any repo with a .venv). Required
-    # because we use mise --shims, which don't run the cd hook that mise's
-    # python.uv_venv_auto relies on. The function autoloads from
-    # ~/.config/fish/functions/__auto_venv.fish; calling it here loads the file
-    # (registering its --on-variable PWD handler) and activates the start dir.
+    # Auto-activate Python virtualenvs on `cd` (any repo with a .venv). mise's
+    # python.uv_venv_auto only covers projects with mise-managed python, which
+    # is intentionally not a global tool — this owns plain-.venv repos. The
+    # function autoloads from ~/.config/fish/functions/__auto_venv.fish; calling
+    # it here loads the file (registering its --on-variable PWD handler) and
+    # activates the start dir.
     __auto_venv
 end

--- a/dot_config/fish/functions/__auto_venv.fish
+++ b/dot_config/fish/functions/__auto_venv.fish
@@ -1,8 +1,8 @@
 function __auto_venv --on-variable PWD --description 'Auto-activate the nearest Python .venv on cd'
     # Auto-activate Python virtualenvs on `cd` for any repo that has a .venv —
-    # including uv projects: mise's python.uv_venv_auto only fires through the
-    # `mise activate` HOOK, which we don't run (we use --shims), so this function
-    # owns ALL interactive venv activation. Activates the nearest ancestor .venv,
+    # including uv projects: mise's python.uv_venv_auto only covers projects with
+    # mise-managed python (intentionally not a global tool), so this function
+    # owns plain-.venv activation. Activates the nearest ancestor .venv,
     # deactivates on leaving its tree, and never touches a venv we didn't activate
     # (manual / mise) — we only ever deactivate the one we started (__auto_venv_dir).
     #

--- a/dot_config/fish/functions/__cached_source.fish
+++ b/dot_config/fish/functions/__cached_source.fish
@@ -3,14 +3,15 @@ function __cached_source --description 'Source a command output with stale-while
     # Example: __cached_source zoxide init fish
     # Example: __cached_source /home/linuxbrew/.linuxbrew/bin/brew shellenv
     #
-    # Caches output to ~/.cache/fish/<name>.fish
+    # Caches output to ~/.cache/fish/<tool>-<subcmds>.fish — the subcommand is
+    # part of the cache key, so changing args (e.g. dropping a flag) invalidates.
     # On cache hit: sources immediately (zero validation cost — all builtins)
     # If tool binary is newer than cache: regenerates in background for next startup
     # Accepts full paths — uses basename for the cache filename.
 
     set -l tool $argv[1]
     set -l subcmd $argv[2..-1]
-    set -l name (string replace -r '.*/' '' $tool)
+    set -l name (string join '-' (string replace -r '.*/' '' $tool) $subcmd | string replace -a '/' '-')
 
     set -l tool_path (command -s $tool 2>/dev/null)
     if test -z "$tool_path"
@@ -31,8 +32,9 @@ function __cached_source --description 'Source a command output with stale-while
     else
         # Cold start: generate synchronously
         mkdir -p $cache_dir
-        # Clean up old versioned cache files (previous naming scheme)
-        for old in $cache_dir/$name.*.fish
+        # Clean up cache files from previous naming schemes (<tool>.fish, <tool>.<ver>.fish)
+        set -l base (string replace -r '.*/' '' $tool)
+        for old in $cache_dir/$base.fish $cache_dir/$base.*.fish
             command rm -f $old
         end
         $tool $subcmd >$cache_file


### PR DESCRIPTION
## Why

Shims mode only generates shims at `mise reshim` time, so binaries added afterward (`cargo install`, `npm i -g`) were invisible — `cargo-audit`, `sync_dis_boi` existed in `~/.cargo/bin` but weren't on PATH. This is inherent to shims mode; mise's own docs recommend PATH activation for interactive shells.

## What

- `zz_01_paths.fish.tmpl`: `mise activate --shims fish` → `mise activate fish`. A `fish_prompt` hook now runs `mise hook-env`, putting real tool bin dirs (incl. `~/.cargo/bin`) on PATH.
- `__cached_source.fish`: cache key now includes the subcommand (`mise-activate-fish.fish` instead of `mise.fish`). Without this, the old cached shims line would keep winning after the config change — args weren't part of the cache key. Old-scheme cache files are cleaned up on cold start, so the switch takes effect on the first shell after `chezmoi apply`, no manual cache clearing.
- `zz_03_interactive.fish` / `__auto_venv.fish`: comment updates only — auto-venv stays (it covers plain-`.venv` repos; mise's `uv_venv_auto` only ever applies to mise-managed python, which is intentionally not a global tool).

## Verification

Ran a sandboxed fish (`XDG_CONFIG_HOME` pointing at a copy of the live config with the new files, clean env) through startup, repeated `fish_prompt` events, and `cd` into/out of a project pinned to `bun = "1.3.10"`:

- **Overrides dir stays first**: `~/.local/share/overrides/bin` was `$PATH[1]` at startup, after repeated prompt hooks, and after version-switching `cd` in both directions — `hook-env` respects PATH entries added after activation.
- `~/.cargo/bin` on PATH; `cargo-audit` (no shim, previously invisible) resolves.
- Shims dir no longer on PATH; `node`/`bun` resolve to real install dirs.
- Version switching works: pinned project → bun 1.3.10, leaving → 1.3.11 (latest).
- Non-interactive `fish -c` still resolves cargo binaries (activation runs one env pass at source time).
- Warm startup 20ms (baseline ~24ms — no regression).

Final PATH shape:
```
~/.local/share/overrides/bin      ← still first
~/.local/share/mise/installs/bun/latest/bin
~/.local/share/mise/installs/node/latest/bin
~/.cargo/bin
~/.local/share/mise/installs/go/1.26.1/bin
~/.local/share/mise/installs/java/latest/bin
/usr/local/bin ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)