### PR TITLE
feat(pacman): Inline third-party repos into pacman.conf via omarchy hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ Scripts use category-based numeric prefixes with gaps for future expansion:
 | `run_onchange_13-install-packages-apt.sh.tmpl` | Debian/Ubuntu packages via apt |
 | `run_onchange_14-install-packages-dnf.sh.tmpl` | Fedora packages via dnf |
 | `run_onchange_15-install-packages-rpm-ostree.sh.tmpl` | Immutable Fedora packages via rpm-ostree |
+| `run_onchange_20-configure-pacman-repos.sh.tmpl` | Splices `~/.config/pacman/custom-repos-{head,tail}.conf` into `/etc/pacman.conf` via the omarchy `pre-refresh-pacman` hook (one sudo); omarchy-only |
 | `run_onchange_30-install-packages-flatpak.sh.tmpl` | Flatpak GUI apps (Linux, tier 4+) |
 | `run_onchange_31-install-packages-appimage.sh.tmpl` | AppImage downloads (Linux, last resort) |
 | `run_onchange_40-install-thpm.sh.tmpl` | Installs THPM (theme-hook-plugin-manager) at a pinned commit; omarchy-only |

--- a/dot_config/omarchy/hooks/pre-refresh-pacman.d/executable_10-custom-repos.sh
+++ b/dot_config/omarchy/hooks/pre-refresh-pacman.d/executable_10-custom-repos.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Splice third-party repo sections into /etc/pacman.conf. Inlined rather than
+# Include'd because cachyos-kernel-manager parses pacman.conf with a plain INI
+# reader and never follows Include lines.
+#
+#   ~/.config/pacman/custom-repos-head.conf -> above [core]  repos that should win over Arch
+#   ~/.config/pacman/custom-repos-tail.conf -> end of file   repos that must never shadow Arch
+#
+# Safe to re-run any time: existing marker blocks are removed and re-spliced
+# from the current snippets, so editing a snippet + running this applies it.
+# `--check` only reports: exit 0 if pacman.conf is current, 2 if it would
+# change. Never escalates.
+#
+# `omarchy refresh pacman` overwrites /etc/pacman.conf from the channel
+# template, runs this hook, then `pacman -Syyuu`.
+set -e
+
+check=0; [[ ${1:-} == --check ]] && check=1
+
+CONF=/etc/pacman.conf
+HEAD=$HOME/.config/pacman/custom-repos-head.conf
+TAIL=$HOME/.config/pacman/custom-repos-tail.conf
+
+[[ -r $HEAD ]] || HEAD=
+[[ -r $TAIL ]] || TAIL=
+[[ -n $HEAD || -n $TAIL ]] || exit 0
+
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+awk -v head="$HEAD" -v tail="$TAIL" '
+  function emit(f) {
+    out[++n] = "# >>> " f " (inlined by pre-refresh-pacman hook) >>>"
+    while ((getline l < f) > 0) out[++n] = l
+    close(f)
+    out[++n] = "# <<< " f " <<<"
+  }
+  # drop any previously spliced block (and the blank line we added after/before it)
+  /^# >>> .* >>>$/ { skip = 1; next }
+  /^# <<< .* <<<$/ { skip = 0; eat_blank = 1; next }
+  skip { next }
+  eat_blank && /^$/ { eat_blank = 0; next }
+  { eat_blank = 0 }
+  head && /^\[core\]/ && !done { emit(head); out[++n] = ""; done = 1 }
+  { out[++n] = $0 }
+  END {
+    while (n && out[n] == "") n--          # trim trailing blanks so tail block never drifts
+    for (i = 1; i <= n; i++) print out[i]
+    if (tail) { n0 = n; out[++n] = ""; emit(tail); for (i = n0 + 1; i <= n; i++) print out[i] }
+  }
+' "$CONF" > "$tmp"
+
+cmp -s "$tmp" "$CONF" && exit 0
+(( check )) && exit 2
+echo "pre-refresh-pacman: splicing${HEAD:+ $HEAD above [core]}${TAIL:+ $TAIL at end}"
+sudo install -m 644 "$tmp" "$CONF"

--- a/dot_config/pacman/custom-repos-head.conf
+++ b/dot_config/pacman/custom-repos-head.conf
@@ -1,0 +1,15 @@
+# Third-party repos spliced ABOVE [core] by the omarchy pre-refresh-pacman hook
+# so these win over stock Arch. Only put repos here that should shadow Arch.
+# Mirrorlists are system-owned (cachyos-mirrorlist package + rate-mirrors).
+
+[cachyos-znver4]
+Include = /etc/pacman.d/cachyos-v4-mirrorlist
+
+[cachyos-core-znver4]
+Include = /etc/pacman.d/cachyos-v4-mirrorlist
+
+[cachyos-extra-znver4]
+Include = /etc/pacman.d/cachyos-v4-mirrorlist
+
+[cachyos]
+Include = /etc/pacman.d/cachyos-mirrorlist

--- a/dot_config/pacman/custom-repos-tail.conf
+++ b/dot_config/pacman/custom-repos-tail.conf
@@ -1,0 +1,6 @@
+# Third-party repos appended at the END of pacman.conf by the omarchy
+# pre-refresh-pacman hook, below Arch and Omarchy, so they can never shadow a
+# distro package. Only supplies their own packages.
+
+[warpdotdev]
+Server = https://releases.warp.dev/linux/pacman/$repo/$arch

--- a/run_onchange_20-configure-pacman-repos.sh.tmpl
+++ b/run_onchange_20-configure-pacman-repos.sh.tmpl
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+{{ if eq .de "hyprland-omarchy" -}}
+# Splice the third-party pacman repo snippets into /etc/pacman.conf via the
+# omarchy pre-refresh-pacman hook, so editing a snippet + `chezmoi apply` takes
+# effect now rather than at the next `omarchy refresh pacman`.
+# Reruns when a snippet or the hook changes (hashes below).
+#   head: {{ include "dot_config/pacman/custom-repos-head.conf" | sha256sum }}
+#   tail: {{ include "dot_config/pacman/custom-repos-tail.conf" | sha256sum }}
+#   hook: {{ include "dot_config/omarchy/hooks/pre-refresh-pacman.d/executable_10-custom-repos.sh" | sha256sum }}
+set -euo pipefail
+
+HOOK="${HOME}/.config/omarchy/hooks/pre-refresh-pacman.d/10-custom-repos.sh"
+[[ -x $HOOK ]] || { echo "pacman repo hook not deployed yet — skipping (will run on next apply)"; exit 0; }
+
+# Nothing to do if pacman.conf already matches the snippets (no sudo needed).
+if "$HOOK" --check; then
+    exit 0
+fi
+
+# The hook needs one sudo (install over /etc/pacman.conf). Escalate when
+# passwordless sudo works or we have a tty to prompt on; otherwise print the
+# command rather than hang a non-interactive apply.
+if sudo -n true 2>/dev/null || [[ -t 0 ]]; then
+    if ! "$HOOK"; then
+        echo "WARN: could not update /etc/pacman.conf (sudo declined/failed). Run later:"
+        echo "  $HOOK"
+    fi
+else
+    echo "NOTE: /etc/pacman.conf needs re-splicing. No passwordless sudo and no tty — run once:"
+    echo "  $HOOK"
+fi
+{{ else -}}
+# Profile '{{ .profile }}' is not omarchy — nothing to do.
+exit 0
+{{ end -}}


### PR DESCRIPTION
## Summary

- replace the two `pre-refresh-pacman` hooks with one that splices snippet contents into `/etc/pacman.conf` between marker comments, instead of adding `Include` lines
- `custom-repos-head.conf` goes above `[core]` (cachyos, wins over Arch); `custom-repos-tail.conf` goes at the end (warp, never shadows a distro package)
- move the snippets from `/etc/pacman.d` to `~/.config/pacman` so chezmoi tracks them
- rerun the splice from `run_onchange_20` when a snippet or the hook changes, with the restic script's sudo guard
- rerunning the hook replaces earlier blocks, so a snippet edit plus `chezmoi apply` (or `omarchy refresh pacman`) lands immediately

## Why

`cachyos-kernel-manager` parses `pacman.conf` with a plain INI reader and never follows `Include`, so it could not see the cachyos repos and listed no `linux-cachyos` kernels. pacman resolves both forms identically, so inlining the sections fixes the manager without changing package resolution. The hook runs as the user and reads the snippets from `$HOME`, so root never needs to read user files.

## Validation

- `pacman-conf --repo-list` order and `pacman -Sp linux-cachyos warp-terminal` unchanged after the migration
- hook run twice on the live file and on the omarchy stable template: second run is a no-op (byte-identical)
- snippet edit then revert round-trips `pacman.conf` back to identical
- `--check` exits 2 on a stale file and 0 when current, without sudo
- kernel manager lists `linux-cachyos` with the installed kernels checked
