### PR TITLE
refactor(mise): Move dotfiles defaults into a conf.d drop-in

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -147,6 +147,10 @@ packages:
     tags: [dev]
     desc: "ping with graph"
 
+  tealdeer:
+    tags: [core]
+    desc: "tldr pages client"
+
   yazi:
     tags: [core]
     desc: "Terminal file manager"
@@ -386,17 +390,6 @@ packages:
     desc: "Hack Nerd Font"
     brew_cask: true
     pacman: ttf-hack-nerd
-
-  # ===========================================================================
-  # Basic UI — Editor
-  # ===========================================================================
-  visual-studio-code-insiders:
-    tags: [ui]
-    desc: "Code editor (Insiders)"
-    brew: "visual-studio-code@insiders"
-    brew_cask: true
-    pacman: visual-studio-code-insiders-bin
-    appimage: tyvsmith/VSCodeInsiders-AppImage
 
 
   # ===========================================================================

--- a/dot_config/mise/conf.d/10-dotfiles.toml.tmpl
+++ b/dot_config/mise/conf.d/10-dotfiles.toml.tmpl
@@ -1,4 +1,13 @@
 {{ if contains "dev" .tags -}}
+# Chezmoi owns this drop-in: language runtimes and mise settings, nothing else.
+# Omarchy owns ~/.config/mise/config.toml, which its ~/.local/bin lazy wrappers
+# rewrite on every launch via `mise use -g`.
+#
+# NOTE: CLI agents (claude, codex, opencode, gemini, ...) are deliberately absent.
+# On omarchy the wrappers install and pin them; declaring them here would fight
+# `mise use -g`. On every other profile they are installed by hand — mise is not
+# the system of record for agents anywhere.
+#
 # NOTE: python intentionally NOT a global tool. mise shims fall through to the
 # next binary on PATH when a tool isn't configured, so leaving python out here
 # makes `python3`/`pip` resolve to /usr/bin/python3 everywhere by default —
@@ -11,9 +20,6 @@ node = "latest"
 rust = "latest"
 go = "latest"
 java = "latest"
-{{- /* Omarchy 4's ~/.local/bin wrappers `mise use -g` these; track them so apply agrees. */}}
-claude = "latest"
-codex = "latest"
 
 [settings]
 idiomatic_version_file_enable_tools = ["node", "python", "go", "ruby", "java", "rust"]


### PR DESCRIPTION
## Summary

- move `dot_config/mise/config.toml.tmpl` to `conf.d/10-dotfiles.toml.tmpl`
- drop `claude` and `codex` from it — the drop-in is language runtimes and `[settings]` only
- add `tealdeer`, drop `visual-studio-code-insiders`

## Why

Omarchy 4's `~/.local/bin` wrappers run `mise use -g` on every launch, writing the
selected tool into `~/.config/mise/config.toml`. Chezmoi rendered that same file, so
every apply reverted whatever the wrappers had selected, and the template carried
`claude` and `codex` only to stop the fight. A `conf.d` drop-in keeps runtime
defaults declarative and leaves `config.toml` to Omarchy.

Agents come out rather than move across: Omarchy installs and pins its own, and on
the other profiles mise was never the right system of record for them. Nothing on
`macos-work`, `devpod`, or `silverblue` installs `claude` or `codex` after this —
install them by hand there.

## Upgrade note

mise gives `config.toml` precedence over `conf.d/*.toml`. A machine that applied the
old template keeps a shadowing copy, so the drop-in stays inert until the
chezmoi-authored `[tools]` entries and `[settings]` block are pruned from
`~/.config/mise/config.toml`. Done on the Arch desktop; the Mac still needs it.

## Validation

- rendered the template with and without the `dev` tag and across `de` values, parsing each result as TOML
- checked that apply leaves the now-unmanaged `config.toml` in place rather than deleting it
- re-ran an Omarchy wrapper afterward to confirm it still targets `config.toml`, not the drop-in
- confirmed `claude` and `codex` still resolve on the Arch desktop from Omarchy's `config.toml`
