### PR TITLE
feat(restic): Include LUKS2 header backups in the system profile

### DIFF
--- a/dot_config/resticprofile/private_profiles.yaml.tmpl
+++ b/dot_config/resticprofile/private_profiles.yaml.tmpl
@@ -174,6 +174,8 @@ system:
       # card comes back at driver defaults - which on the Maxwell dongle is a silent
       # 20 dB drop on PCM,1 that reads as a hardware fault, not a settings loss.
       - /var/lib/alsa
+      # LUKS2 header backups; a damaged header loses the volume, and nothing else captures them.
+      - /root/luks-headers
     exclude-caches: true
     tag:
       - "{{ $host }}"


### PR DESCRIPTION
- add `/root/luks-headers` to the `system` profile source list

A damaged LUKS2 header loses the volume, and `/root` fell outside both profile source lists.
